### PR TITLE
Add Monk vocation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Changelog
     Due to this library relying on external content, older versions are not guaranteed to work.
     Try to always use the latest version.
 
+.. v6.4.0
+
+6.4.0 (unreleased)
+==================
+- Add Monk vocation (``Vocation.MONK`` / ``Vocation.EXALTED_MONK``) and the matching ``AuctionVocationFilter``, ``HighscoresProfession`` and ``SpellVocationFilter`` entries.
+
 .. v6.3.0
 
 6.3.0 (2024-04-05)

--- a/tests/tests_enums.py
+++ b/tests/tests_enums.py
@@ -1,6 +1,7 @@
 import tibiapy.enums
 from tests.tests_tibiapy import TestCommons
 from tibiapy.models import AuctionFilters
+from tibiapy.utils import try_enum
 
 
 class TestEnums(TestCommons):
@@ -30,3 +31,13 @@ class TestEnums(TestCommons):
         self.assertEqual(tibiapy.enums.HighscoresProfession.ALL,
                          tibiapy.enums.HighscoresProfession.from_name("anything"))
         self.assertIsNone(tibiapy.enums.HighscoresProfession.from_name("anything", all_fallback=False))
+
+    def test_vocation_includes_monk(self):
+        """Monk vocations must resolve, otherwise bazaar pages containing a Monk fail to parse."""
+        self.assertEqual(tibiapy.enums.Vocation.MONK, tibiapy.enums.Vocation("Monk"))
+        self.assertEqual(tibiapy.enums.Vocation.EXALTED_MONK, tibiapy.enums.Vocation("Exalted Monk"))
+        self.assertEqual(tibiapy.enums.Vocation.MONK, tibiapy.enums.Vocation.EXALTED_MONK.base)
+        # The bazaar parser resolves vocations through try_enum; "Monk" previously returned None.
+        self.assertEqual(tibiapy.enums.Vocation.MONK, try_enum(tibiapy.enums.Vocation, "Monk"))
+        self.assertEqual(tibiapy.enums.Vocation.EXALTED_MONK,
+                         try_enum(tibiapy.enums.Vocation, "Exalted Monk"))

--- a/tibiapy/enums.py
+++ b/tibiapy/enums.py
@@ -212,6 +212,7 @@ class AuctionVocationFilter(NumericEnum):
     KNIGHT = 3
     PALADIN = 4
     SORCERER = 5
+    MONK = 6
 
 
 class AvailableForumSection(StringEnum):
@@ -322,6 +323,7 @@ class HighscoresProfession(NumericEnum):
     PALADINS = 3
     SORCERERS = 4
     DRUIDS = 5
+    MONKS = 6
 
     @classmethod
     def from_name(cls, name: str, all_fallback: bool = True) -> Optional[Self]:
@@ -479,6 +481,7 @@ class SpellVocationFilter(StringEnum):
     KNIGHT = "Knight"
     PALADIN = "Paladin"
     SORCERER = "Sorcerer"
+    MONK = "Monk"
 
 
 class ThreadStatus(Flag):
@@ -555,10 +558,12 @@ class Vocation(StringEnum):
     KNIGHT = "Knight"
     PALADIN = "Paladin"
     SORCERER = "Sorcerer"
+    MONK = "Monk"
     ELDER_DRUID = "Elder Druid"
     ELITE_KNIGHT = "Elite Knight"
     ROYAL_PALADIN = "Royal Paladin"
     MASTER_SORCERER = "Master Sorcerer"
+    EXALTED_MONK = "Exalted Monk"
 
     @property
     def base(self) -> Self:
@@ -571,6 +576,8 @@ class Vocation(StringEnum):
             return self.PALADIN
         if self == self.ELITE_KNIGHT:
             return self.KNIGHT
+        if self == self.EXALTED_MONK:
+            return self.MONK
         return self
 
 


### PR DESCRIPTION
## What
Adds the **Monk** vocation (and its promotion, **Exalted Monk**) to `tibiapy.enums`, fixing the bazaar parse failure reported in #47.

## Why
`Vocation` has no `MONK`/`EXALTED_MONK` member. When a Monk is on a Char Bazaar page, `try_enum(Vocation, "Monk")` returns `None`, and the required `Auction.vocation` field rejects it — so the **entire page** fails with:

```
InvalidContentError: content does not belong to the bazaar at Tibia.com
```

Monks are now common on the bazaar, so `fetch_current_auctions` / `fetch_auction_history` break on any page containing one.

## Changes
- `Vocation`: add `MONK = "Monk"` and `EXALTED_MONK = "Exalted Monk"`, and map `EXALTED_MONK.base → MONK`.
- `AuctionVocationFilter.MONK`, `HighscoresProfession.MONKS`, `SpellVocationFilter.MONK` for complete vocation coverage.
- Regression test in `tests/tests_enums.py` (covers `Vocation("Monk")`, `Vocation("Exalted Monk").base`, and the `try_enum` path the parser actually uses).
- CHANGELOG entry.

## Notes
- Focused on the vocation only. (Prior PR #45 added this too, but bundled an unrelated `WeaponProficiency` feature and was orphaned when its author's account was deleted — so the fix was lost rather than rejected.)
- I left `__version__` untouched and used a `6.4.0 (unreleased)` CHANGELOG header — happy to adjust the version/date to match your release process.
- The numeric filter values (`AuctionVocationFilter.MONK = 6`, `HighscoresProfession.MONKS = 6`) follow the existing sequential pattern (and match #45); worth a quick double-check against the live forms.

## Testing
`tests_enums.py`, `tests_bazaar.py`, `tests_character.py` pass locally (28 passed). The new test fails on `main` and passes with this change.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
